### PR TITLE
Introduce new `tag-to-name` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ jobs:
 
 ## Inputs
 
-|         key          |      default      |              possible values               |                                                            description                                                             |
-| :------------------: | :---------------: | :----------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------: |
-|        `tag`         | `github.ref_name` |                any tag name                |                            The annotated tag for the release, containing the release's title and notes.                            |
-|       `token`        |  `github.token`   |              any valid token               |                                           The GitHub token to use to create the release.                                           |
-|       `draft`        |      `false`      |              `true`, `false`               |                                           Creates the release as a draft if set to true.                                           |
-|      `dry-run`       |      `false`      |              `true`, `false`               |                       Use this to prevent a release from being created. Useful if you only need the outputs.                       |
-|     `prerelease`     |      `false`      | `true`, `false`, `always`, `never`, `auto` | Set `true` to always create a prerelease. Set to `auto` to create a prerelease when the tag matches the prerelease pattern (below) |
-| `prerelease-pattern` |    `v*.*.*-*`     |          See [minimatch] patterns          |                                         Pattern to match to the tag to detect a prerelease                                         |
+|         key          |      default      |              possible values               |                                                                                                           description                                                                                                            |
+|:--------------------:|:-----------------:|:------------------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|        `tag`         | `github.ref_name` |                any tag name                |                                                                           The annotated tag for the release, containing the release's title and notes.                                                                           |
+|       `token`        |  `github.token`   |              any valid token               |                                                                                          The GitHub token to use to create the release.                                                                                          |
+|       `draft`        |      `false`      |              `true`, `false`               |                                                                                          Creates the release as a draft if set to true.                                                                                          |
+|    `tag-as-name`     |      `false`      |              `true`, `false`               | If `true`, the tag itself becomes the release name and the entire tag message including the subject becomes the release body. If `false`, the tag subject becomes the release name and the rest of the message becomes the body. |
+|      `dry-run`       |      `false`      |              `true`, `false`               |                                                                      Use this to prevent a release from being created. Useful if you only need the outputs.                                                                      |
+|     `prerelease`     |      `false`      | `true`, `false`, `always`, `never`, `auto` |                                                Set `true` to always create a prerelease. Set to `auto` to create a prerelease when the tag matches the prerelease pattern (below)                                                |
+| `prerelease-pattern` |    `v*.*.*-*`     |          See [minimatch] patterns          |                                                                                        Pattern to match to the tag to detect a prerelease                                                                                        |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,15 @@ inputs:
     description: If the release should be a draft
     required: true
     default: false
+  tag-as-name:
+    description: >
+      If the tag itself should be used as the release name.
+      If true, the entire tag message, including the subject line (first line)
+      is used as the text body of the release.
+      If false, the subject line of the tag message is used as the release name
+      and the rest of the tag message is used as the release text body.
+    required: true
+    default: false
   prerelease:
     description: >
       If the release should be a prerelease.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,13 @@ export function parseDraft(): boolean {
   return val
 }
 
+export function parseTagAsName(): boolean {
+  const input = getInput('tag-as-name')
+  const val = inputAsBoolean(input)
+  if (val === null) throw new Error(`Invalid tag-as-name value: ${input}`)
+  return val
+}
+
 export function parsePrerelease(): PrereleaseConfig {
   const input = getInput('prerelease')
   if (input === 'auto') return 'auto'

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {
   parseDraft,
   parseDryRun,
   parsePrerelease,
+  parseTagAsName,
   prereleasePattern,
   tag as rawTag,
   token
@@ -16,7 +17,11 @@ async function run(): Promise<void> {
 
   const tag = new Tag(rawTag)
 
-  const [name, body] = await Promise.all([tag.getSubject(), tag.getBody()])
+  const tagAsName = parseTagAsName()
+  debug(`Tag as name: ${tagAsName}`)
+
+  const name = tagAsName ? rawTag : await tag.getSubject()
+  const body = await tag.getBody(tagAsName)
   debug(`Release Name: ${name}`)
   setOutput('title', name)
   debug(`Release Body: ${body}`)

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -4,11 +4,11 @@ export default class Tag {
   constructor(public tag: string) {}
 
   async getSubject(): Promise<string> {
-    return await this.getTagContents('subject')
+    return await this.getTagContents('contents:subject')
   }
 
-  async getBody(): Promise<string> {
-    return await this.getTagContents('body')
+  async getBody(includeSubject: boolean): Promise<string> {
+    return await this.getTagContents(includeSubject ? 'contents' : 'contents:body')
   }
 
   private async getTagContents(contents: string): Promise<string> {
@@ -17,7 +17,7 @@ export default class Tag {
 
     await exec(
       'git',
-      ['tag', '-l', `--format=%(contents:${contents})`, this.tag],
+      ['tag', '-l', `--format=%(${contents})`, this.tag],
       {
         listeners: {
           stdout: (data: Buffer) => {


### PR DESCRIPTION
I like this action a lot, but I would like to have the option for it to automatically use the **entire tag message** as the release text body and use the **tag itself** (e.g. `v1.0.42`) as the name/title of the release. I hope that makes sense.

I know I could use your action as is and just repeat the tag name in the subject line of the message, but this would be a redundancy that I do not like very much.

I could also just manually edit the release text and title after it was auto-generated by the action, but this partially defeats the purpose of using an automated generation process.

These changes should keep your current approach of using the git tag subject line as the release name and the rest of the message as the body as the default, so it should not break anything.

My experience with TypeScript is almost non-existent, so I hope my changes are not completely broken. If you think this PR is worthwhile and something is wrong/missing, I'll do my best to fix it.